### PR TITLE
Refactor: NavigationManager no longer relies on hardcoded page names

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -6,7 +6,7 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using Avalonia.Threading;
 using Inferyn.Managers;
-using Inferyn.Managers;
+using Inferyn.Pages;
 
 namespace Inferyn;
 
@@ -51,6 +51,8 @@ public partial class App : Application
                 Dispatcher.UIThread.Post(async () =>
                 {
                     // Create application pages
+                    await NavigationManager.CreatePage(new MainPage());
+                    await NavigationManager.CreatePage(new UpdatePage());
 
                     // IMPORTANT: MainWindow must be created after all pages are created, otherwise,
                     // the first page will be initialized twice

--- a/Interfaces/IPage.cs
+++ b/Interfaces/IPage.cs
@@ -15,6 +15,8 @@ namespace Inferyn.Interfaces;
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 public interface IPage
 {
+    string NavigationName { get; }
+
     /// <summary>
     /// Called when the page is first created. Code that needs to be loaded during the splash screen should be
     /// placed here.

--- a/Managers/NavigationManager.cs
+++ b/Managers/NavigationManager.cs
@@ -12,7 +12,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Avalonia.Controls;
-using Inferyn.Pages;
+using Inferyn.Interfaces;
 using Inferyn.Windows;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -33,12 +33,7 @@ public static class NavigationManager
     /// <summary>
     /// The pages that can be navigated to.
     /// </summary>
-    private static readonly Dictionary<string, UserControl?> Pages =
-        new()
-        {
-            { "MainPage", null },
-            { "UpdatePage", null },
-        };
+    private static readonly Dictionary<string, UserControl?> Pages = new();
 
     /// <summary>
     /// The current page.
@@ -52,12 +47,7 @@ public static class NavigationManager
     /// <summary>
     /// Contains a dictionary of pages and whether they have been loaded.
     /// </summary>
-    private static readonly Dictionary<string, bool> LoadedPages =
-        new()
-        {
-            { "MainPage", false },
-            { "UpdatePage", false },
-        };
+    private static readonly Dictionary<string, bool> LoadedPages = new();
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // NAVIGATION
@@ -67,52 +57,42 @@ public static class NavigationManager
     /// Switches the page to the specified page.
     /// </summary>
     /// <param name="mainWindow">The main window.</param>
-    /// <param name="page">The page to switch to.</param>
-    public static void SwitchPage(MainWindow mainWindow, string page)
+    /// <param name="pageName">The NavigationName of the page to switch to.</param>
+    public static void SwitchPage(MainWindow mainWindow, string pageName)
     {
         var pageContent = mainWindow.FindControl<ContentControl>("PageContent");
         if (pageContent == null)
             return;
 
-        if (!Pages.ContainsKey(page))
+        if (!Pages.ContainsKey(pageName))
             return;
 
-        if (Pages[page] == null)
+        if (Pages[pageName] == null)
         {
-            Pages[page] = CreatePageInstance(page);
+            // Page must already be created and registered with CreatePage
+            return;
         }
 
-        if (!LoadedPages[page])
+        if (!LoadedPages[pageName])
         {
-            LoadedPages[page] = true;
-            (Pages[page] as dynamic)?.OnFirstLoad();
+            LoadedPages[pageName] = true;
+            (Pages[pageName] as dynamic)?.OnFirstLoad();
         }
 
-        pageContent.Content = Pages[page];
-        _currentPage = Pages[page];
-        (Pages[page] as dynamic)?.OnNavigatedTo();
+        pageContent.Content = Pages[pageName];
+        _currentPage = Pages[pageName];
+        (Pages[pageName] as dynamic)?.OnNavigatedTo();
     }
 
     /// <summary>
-    /// Helper for creating an instance of the specified page.
+    /// Registers a page instance.
     /// </summary>
-    /// <param name="pageName"></param>
-    /// <returns></returns>
-    private static UserControl? CreatePageInstance(string pageName) =>
-        pageName switch
-        {
-            "MainPage" => new MainPage(),
-            "UpdatePage" => new UpdatePage(),
-            _ => null,
-        };
-
-    /// <summary>
-    /// Creates an instance of the specified page.
-    /// </summary>
-    /// <param name="name"></param>
-    public static async Task CreatePage(string name)
+    /// <param name="page">The page instance implementing IPage.</param>
+    public static async Task CreatePage(IPage page)
     {
-        Pages[name] = CreatePageInstance(name);
+        var pageKey = page.NavigationName;
+        Pages[pageKey] = page as UserControl;
+        LoadedPages[pageKey] = false;
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -133,3 +113,4 @@ public static class NavigationManager
     public static Control? GetPage(string name) =>
         Pages.ContainsKey(name) ? Pages[name] : new Control();
 }
+

--- a/Pages/MainPage.axaml.cs
+++ b/Pages/MainPage.axaml.cs
@@ -46,6 +46,8 @@ public partial class MainPage : UserControl, IPage
         CreateChat();
     }
 
+    public string NavigationName { get; } = "MainPage";
+
     public void Initialize()
     {
         InitializeComponent();

--- a/Pages/UpdatePage.axaml.cs
+++ b/Pages/UpdatePage.axaml.cs
@@ -50,6 +50,8 @@ public partial class UpdatePage : UserControl, IPage
     // IPAGE INTERFACE IMPLEMENTATION
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+    public string NavigationName { get; } = "UpdatePage";
+
     /// <summary>
     /// Initializes the update page.
     /// </summary>


### PR DESCRIPTION
Refactor: NavigationManager now uses IPage.NavigationName dynamically instead of relying on hardcoded page names.

More Details:
- Removed hardcoded page names and switch statements from NavigationManager
- Pages are not registered via CreatePage(IPage) and identified by their NavigationName
- Supports any page implementing IPage without further changes to NavigationManager